### PR TITLE
adding script to deface T1w.nii files

### DIFF
--- a/deface_T1w.sh
+++ b/deface_T1w.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# script for defacing nifti images
+#
+# requires Python module pydeface.
+# written by Megan Finnegan
+
+
+dataDir="/Data/"
+currDir=$(pwd)
+
+# deface images
+find "$dataDir" -type f -name '*T1w.nii.gz' -execdir pydeface "{}" \;
+
+# rename output -- note that find does not support string substitution and 
+# it is expensive to start a subshell for a simple move command. Hence this.
+find "$dataDir" -type f -name '*T1w_defaced.nii.gz' -print0 | 
+	while IFS= read -r -d '' file; do
+		mv $file "${file/_defaced.nii.gz/.nii.gz}"
+	done


### PR DESCRIPTION
Note that:

1. This only looks for T1w images to deface. Do you want to add functionality to deface other image types like T2w?
2. This first pass looks for all T1w.nii.gz images and defaces them, then it does another pass to find all images that are label T1w_defaced.nii.gz and renames them to be BIDS compliant. There are no use cases where this 2-pass approach would be an issue correct?